### PR TITLE
flip and flip capitalizes some characters

### DIFF
--- a/modules/emotes/__init__.py
+++ b/modules/emotes/__init__.py
@@ -42,7 +42,7 @@ class EmotesModule(commands.Cog):
         norm = norm_lower + norm_upper + norm_number + norm_extra
 
         flip_lower  = "ɐqɔpǝɟƃɥᴉɾʞlɯuodbɹsʇnʌʍxʎz"
-        flip_upper  = "∀qƆpƎℲפHIſʞ˥WNOԀQᴚS┴∩ΛMX⅄Z"
+        flip_upper  = "∀ΣƆⱭƎℲפHIſK˥WNOԀQᴚS┴∩ΛMX⅄Z"
         flip_number = "0ІᘔƐᔭ59Ɫ86"
         flip_extra  = ")(]["
         flip = flip_lower + flip_upper + flip_number + flip_extra


### PR DESCRIPTION
When _b_, _d_ or _k_ were flipped and reflipped they became capitalised because in the mapping they are mapped to the same flip-char,

B -> Σ
D -> Ɑ
K -> K (didn't found an alternative)

Happens to Cerberus